### PR TITLE
Update Bicep infra: Azure Maps SKU, build env, and startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Azure Maps Flask Sample Application
+# Azure Maps - Simple Sample Application
 
 This is a sample Python Flask web application that demonstrates how to interact with Azure Maps. The app allows users to calculate routes, estimate fuel or electric efficiency, and view real-time traffic incidents on a map.
 
@@ -43,7 +43,7 @@ This is a sample Python Flask web application that demonstrates how to interact 
 
 You can deploy this app and all required Azure resources (including Azure Maps) using the Bicep template below.
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fyour-org%2FPOCAzureMaps%2Fmain%2Finfra%2Fmain.bicep)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Frichardsonbq%2Fazuremaps-sample%2Fmain%2Finfra%2Fmain.bicep)
 
 ### Bicep Deployment Steps
 1. Click the **Deploy to Azure** button above.
@@ -110,15 +110,12 @@ az webapp deployment source config --name <app-name> --resource-group <resource-
 ---
 
 ## Project Structure
-- `app.py` - Flask backend
-- `templates/index.html` - Main UI
+- `app.py` - Flask backend (APIs)
+- `templates/index.html` - Frontend
 - `requirements.txt` - Python dependencies
-- `infra/main.bicep` - Bicep IaC for Azure deployment
+- `infra/main.bicep` - Bicep Infra as Code for Azure resources deployment
 
 ## License
 This project is licensed under the [MIT License](https://opensource.org/licenses/MIT). You are free to use, modify, and distribute this software with proper attribution. See the LICENSE file for details.
 
 ---
-
-**This sample demonstrates how to build and deploy a Python web app that interacts with Azure Maps, including route, efficiency, and incident calculations.**
-

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -6,7 +6,7 @@ param appLocation string = resourceGroup().location
 @allowed(['eastus','westus2','westeurope','northeurope','southeastasia','australiaeast','japaneast','uksouth','francecentral','germanywestcentral','brazilsouth','canadacentral','centralus','southcentralus','swedencentral','switzerlandnorth','uaenorth','norwayeast','koreacentral','indiacentral','polandcentral'])
 param mapsLocation string = 'eastus'
 param sku string = 'B1'
-param mapsSkuName string = 'S1'
+param mapsSkuName string = 'G2'
 
 resource maps 'Microsoft.Maps/accounts@2023-06-01' = {
   name: '${appName}-maps'
@@ -57,7 +57,12 @@ resource webapp 'Microsoft.Web/sites@2022-03-01' = {
           name: 'FLASK_ENV'
           value: 'production'
         }
+        {
+          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
+          value: 'true'
+        }
       ]
+      appCommandLine: 'gunicorn --bind=0.0.0.0 --timeout 600 app:app'
     }
     httpsOnly: true
   }


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to improve clarity and accuracy, as well as modifications to the Bicep infrastructure template to enhance deployment configurations. Below is a breakdown of the most important changes:

### Documentation Updates:
* Updated the title in `README.md` to "Azure Maps - Simple Sample Application" for better clarity and removed redundant details.
* Updated the "Deploy to Azure" button link to point to the correct repository (`richardsonbq/azuremaps-sample`).
* Improved descriptions in the "Project Structure" section of `README.md` to clarify the roles of files, such as specifying `app.py` as "Flask backend (APIs)" and `infra/main.bicep` as "Bicep Infra as Code for Azure resources deployment."

### Infrastructure Template Enhancements:
* Changed the default `mapsSkuName` parameter in `infra/main.bicep` from `S1` to `G2`, to support the Gen2 tier of Azure Maps service.
* Added new app settings in the `infra/main.bicep` file:
  - `SCM_DO_BUILD_DURING_DEPLOYMENT` set to `true` to enable build during deployment.
  - `appCommandLine` set to use `gunicorn` with specific configurations for production readiness.